### PR TITLE
Better CreateExternGenBits

### DIFF
--- a/testu01/README.md
+++ b/testu01/README.md
@@ -19,23 +19,42 @@ possible your distribution provides a package for TestU01 already:
 
 - for Archlinux: `testu01`, in AUR.
 
-Naming Convention
------------------
+API Changes
+-----------
 
-The naming convention remains close to that of TestU01, on purpose. The
-differences are the following:
+The OCaml API remains as close to that of TestU01 as possible. Some changes are
+still introduced to provide a more “OCaml-like” interface. The differences are
+the following:
 
-- The library is all under a main module `Testu01` (or `Probdist` for that other
-  related library).
+- The names have changed:
 
-- The functions, variables and types are not prefixed by the part of the library
-  they belong to, but are in a corresponding module.
+  - The library is all under a main module `Testu01` (or `Probdist` for that
+    other related library).
 
-- The names are with underscore and not in Camel case.
+  - The functions, variables and types are not prefixed by the part of the
+    library they belong to, but are in a corresponding module.
+
+  - The names are with underscore and not in Camel case.
 
 - The global variables are read and modified using getters and setters.
 
-For instance, the binding for the function:
+- The creation of external generators is done with three functions similar to
+  that of the C library:
+
+  - `Testu01.Unif01.create_extern_gen_bits` takes an OCaml “bits” function, that
+    is a function that returns an integer between `0` and `2^30`. This is the
+    case of `Random.bits`, for instance.
+
+  - `Testu01.Unif01.create_extern_gen_int32` takes an OCaml function that
+    returns an `int32`.
+
+  - `Testu01.Unif01.create_extern_gen_01` takes an OCaml function that returns a
+    float between `0` and `1`.
+
+- The destruction of external generators is let to OCaml's garbage collector and
+  cannot be done by hand.
+
+About the name changes, here are a few examples. The binding for the function:
 
 ```c
 void bbattery_RepeatBigCrush(unif01_Gen* gen, int[] rep);
@@ -85,7 +104,7 @@ a report on the standard output, similar to the following:
  11  BirthdaySpacings, t = 2          eps
  31  Gap, r = 0                       eps
  33  Gap, r = 0                       eps
- 47  SampleMean                      0.9940 
+ 47  SampleMean                      0.9940
  51  WeightDistrib, r = 0             eps
  52  WeightDistrib, r = 8             eps
  53  WeightDistrib, r = 16            eps

--- a/testu01/testu01/dune
+++ b/testu01/testu01/dune
@@ -6,4 +6,4 @@
    swrite_stubs
    unif01_stubs
   ))
- (c_library_flags -ltestu01))
+ (c_library_flags -ltestu01 -lmylib))

--- a/testu01/testu01/dune
+++ b/testu01/testu01/dune
@@ -6,4 +6,4 @@
    swrite_stubs
    unif01_stubs
   ))
- (c_library_flags -ltestu01 -lmylib))
+ (c_library_flags -ltestu01))

--- a/testu01/testu01/unif01.ml
+++ b/testu01/testu01/unif01.ml
@@ -1,3 +1,13 @@
 type gen
 
 external create_extern_gen_bits : string -> (unit -> int) -> gen = "caml_unif01_CreateExternGenBits"
+
+let create_extern_gen_bits name bits =
+  (* Add a test that the [bits] function does not provide more than 30, in which
+     case they would be lost. Doing the test every time does not have any real
+     impact on the performances. *)
+  create_extern_gen_bits name (fun () ->
+      let b = bits () in
+      if b lsr 30 <> 0 then
+        invalid_arg "more than 30 bits received";
+      b)

--- a/testu01/testu01/unif01.ml
+++ b/testu01/testu01/unif01.ml
@@ -1,5 +1,3 @@
 type gen
 
 external create_extern_gen_bits : string -> (unit -> int) -> gen = "caml_unif01_CreateExternGenBits"
-
-external delete_extern_gen_bits : gen -> unit = "caml_unif01_DeleteExternGenBits"

--- a/testu01/testu01/unif01.ml
+++ b/testu01/testu01/unif01.ml
@@ -11,3 +11,15 @@ let create_extern_gen_bits name bits =
       if b lsr 30 <> 0 then
         invalid_arg "more than 30 bits received";
       b)
+
+external create_extern_gen_01 : string -> (unit -> float) -> gen = "caml_unif01_CreateExternGen01"
+
+let create_extern_gen_01 name bits =
+  (* Add a test that the [bits] function provides a float in [0, 1). The
+     contrary could provoke segmentation faults in certain tests. Doing the test
+     every time does not have any real impact on the performances. *)
+  create_extern_gen_01 name (fun () ->
+      let b = bits () in
+      if b < 0. || b >= 1. then
+        invalid_arg "float outside of [0, 1) received";
+      b)

--- a/testu01/testu01/unif01.ml
+++ b/testu01/testu01/unif01.ml
@@ -12,6 +12,8 @@ let create_extern_gen_bits name bits =
         invalid_arg "more than 30 bits received";
       b)
 
+external create_extern_gen_int32 : string -> (unit -> int32) -> gen = "caml_unif01_CreateExternGenInt32"
+
 external create_extern_gen_01 : string -> (unit -> float) -> gen = "caml_unif01_CreateExternGen01"
 
 let create_extern_gen_01 name bits =

--- a/testu01/testu01/unif01_stubs.c
+++ b/testu01/testu01/unif01_stubs.c
@@ -108,6 +108,29 @@ value caml_unif01_CreateExternGenBits(value bname, value bbits) {
   CAMLreturn(caml_unif01_CreateExternGen(bname, bbits, CGB_U01, CGB_Bits));
 }
 
+/* ************************** [ ExternGenInt32 ] **************************** */
+
+static uint32_t CGI32_BitsInt (void * bits) {
+  return Int32_val(caml_callback((value) bits, Val_unit));
+}
+
+static unsigned long CGI32_Bits (void * bits, void * junk) {
+  return CGI32_BitsInt(bits);
+}
+
+static double CGI32_U01 (void * bits, void * junk) {
+  // One must avoid casting the int to a long before the division, because
+  // casting to long fills the other bits with 1, and the result will not give a
+  // number between 0 and 1. This is why U01 does not depend on Bits but on an
+  // additional BitsInt, providing an unsigned int.
+  return CGI32_BitsInt(bits) / unif01_NORM32;
+}
+
+value caml_unif01_CreateExternGenInt32(value bname, value bbits) {
+  CAMLparam2(bname, bbits);
+  CAMLreturn(caml_unif01_CreateExternGen(bname, bbits, CGI32_U01, CGI32_Bits));
+}
+
 /* **************************** [ ExternGen01 ] ***************************** */
 
 static double CG01_U01 (void * bits, void * junk) {

--- a/testu01/testu01/unif01_stubs.c
+++ b/testu01/testu01/unif01_stubs.c
@@ -10,6 +10,8 @@
 #include <unif01.h>
 #include "unif01_stubs.h"
 
+#define IGNORE(x) (void)(x)
+
 /* ***************************** [ unif01_Gen ] ***************************** */
 
 void finalize_unif01_Gen_boxed(value bgen) {
@@ -23,12 +25,12 @@ void finalize_unif01_Gen_boxed(value bgen) {
 }
 
 static struct custom_operations unif01_Gen_boxed = {
- identifier: "fr.boloss.testu01.unif01_Gen",
- finalize: finalize_unif01_Gen_boxed,
- compare: custom_compare_default,
- hash: custom_hash_default,
- serialize: custom_serialize_default,
- deserialize: custom_deserialize_default
+ .identifier = "fr.boloss.testu01.unif01_Gen",
+ .finalize = finalize_unif01_Gen_boxed,
+ .compare = custom_compare_default,
+ .hash = custom_hash_default,
+ .serialize = custom_serialize_default,
+ .deserialize = custom_deserialize_default
 };
 
 /* **************************** [ ExternGen* ] ****************************** */
@@ -48,7 +50,7 @@ static struct custom_operations unif01_Gen_boxed = {
 // written in a static way: they simply take the closure as a parameter and make
 // an OCaml call to it.
 
-static void WrExternGen (void * junk) {}
+static void WrExternGen (void * junk) { IGNORE(junk); }
 
 value caml_unif01_CreateExternGen(value bname, value bbits,
                                   double (*GetU01)(void*,void*),
@@ -66,10 +68,10 @@ value caml_unif01_CreateExternGen(value bname, value bbits,
   gen->GetU01 = GetU01;
   gen->GetBits = GetBits;
 
-  char * name = Bytes_val(bname);
-  size_t len = strlen(name);
+  unsigned char* name = Bytes_val(bname);
+  size_t len = strlen((char*)name);
   gen->name = calloc(len + 2, sizeof(char));
-  strncpy(gen->name, name, len);
+  strncpy(gen->name, (char*)name, len);
 
   bgen = caml_alloc_custom(&unif01_Gen_boxed, sizeof(unif01_Gen*), 0, 1);
   memcpy(Data_custom_val(bgen), &gen, sizeof(unif01_Gen*));
@@ -90,10 +92,12 @@ static unsigned int CGB_BitsInt (void * bits) {
 }
 
 static unsigned long CGB_Bits (void * bits, void * junk) {
+  IGNORE(junk);
   return CGB_BitsInt(bits);
 }
 
 static double CGB_U01 (void * bits, void * junk) {
+  IGNORE(junk);
   // One must avoid casting the int to a long before the division, because
   // casting to long fills the other bits with 1, and the result will not give a
   // number between 0 and 1. This is why U01 does not depend on Bits but on an
@@ -113,10 +117,12 @@ static uint32_t CGI32_BitsInt (void * bits) {
 }
 
 static unsigned long CGI32_Bits (void * bits, void * junk) {
+  IGNORE(junk);
   return CGI32_BitsInt(bits);
 }
 
 static double CGI32_U01 (void * bits, void * junk) {
+  IGNORE(junk);
   // One must avoid casting the int to a long before the division, because
   // casting to long fills the other bits with 1, and the result will not give a
   // number between 0 and 1. This is why U01 does not depend on Bits but on an
@@ -132,6 +138,7 @@ value caml_unif01_CreateExternGenInt32(value bname, value bbits) {
 /* **************************** [ ExternGen01 ] ***************************** */
 
 static double CG01_U01 (void * bits, void * junk) {
+  IGNORE(junk);
   return Double_val(caml_callback((value) bits, Val_unit));
 }
 

--- a/testu01/testu01/unif01_stubs.c
+++ b/testu01/testu01/unif01_stubs.c
@@ -7,7 +7,6 @@
 #include <caml/bigarray.h>
 #include <caml/custom.h>
 
-#include <util.h>
 #include <unif01.h>
 #include "unif01_stubs.h"
 
@@ -16,10 +15,9 @@
 void finalize_unif01_Gen_boxed(value bgen) {
   unif01_Gen * gen = unif01_Gen_unbox(bgen);
 
-  gen->state = util_Free(gen->state);
   caml_remove_global_root((value*) &gen->param);
-  gen->name = util_Free(gen->name);
-  util_Free(gen);
+  free(gen->name);
+  free(gen);
 
   return;
 }
@@ -60,7 +58,7 @@ value caml_unif01_CreateExternGen(value bname, value bbits,
   CAMLlocal1(bgen);
   unif01_Gen * gen;
 
-  gen = util_Malloc(sizeof(unif01_Gen));
+  gen = malloc(sizeof(unif01_Gen));
   gen->state = NULL;
   caml_register_global_root((value*) &gen->param);
   gen->param = (void*) bbits;
@@ -70,7 +68,7 @@ value caml_unif01_CreateExternGen(value bname, value bbits,
 
   char * name = Bytes_val(bname);
   size_t len = strlen(name);
-  gen->name = util_Calloc(len + 2, sizeof(char));
+  gen->name = calloc(len + 2, sizeof(char));
   strncpy(gen->name, name, len);
 
   bgen = caml_alloc_custom(&unif01_Gen_boxed, sizeof(unif01_Gen*), 0, 1);

--- a/testu01/testu01/unif01_stubs.c
+++ b/testu01/testu01/unif01_stubs.c
@@ -17,6 +17,7 @@ void finalize_unif01_Gen_boxed(value bgen) {
   unif01_Gen * gen = unif01_Gen_unbox(bgen);
 
   gen->state = util_Free(gen->state);
+  caml_remove_global_root((value*) &gen->param);
   gen->name = util_Free(gen->name);
   util_Free(gen);
 
@@ -63,6 +64,7 @@ value caml_unif01_CreateExternGenBits(value bname, value bbits) {
 
   gen = util_Malloc(sizeof(unif01_Gen));
   gen->state = NULL;
+  caml_register_global_root((value*) &gen->param);
   gen->param = (void*) bbits;
   gen->Write = WrExternGen;
   gen->GetU01 = CGB_U01;

--- a/testu01/testu01/unif01_stubs.c
+++ b/testu01/testu01/unif01_stubs.c
@@ -23,7 +23,7 @@ void finalize_unif01_Gen_boxed(value bgen) {
 }
 
 static struct custom_operations unif01_Gen_boxed = {
- identifier: "unif01_Gen_boxed",
+ identifier: "fr.boloss.testu01.unif01_Gen",
  finalize: finalize_unif01_Gen_boxed,
  compare: custom_compare_default,
  hash: custom_hash_default,

--- a/testu01/testu01/unif01_stubs.c
+++ b/testu01/testu01/unif01_stubs.c
@@ -34,13 +34,19 @@ static struct custom_operations unif01_Gen_boxed = {
 
 /* *************************** [ ExternGenBits ] **************************** */
 
+static unsigned int EGB_CamlBits (void * bits) {
+  return Int_val(caml_callback((value) bits, Val_unit)) << 2;
+}
+
 static unsigned long EGB_Bits (void * bits, void * junk) {
-  value bbits = (value) bits;
-  return Int_val(caml_callback(bbits, Val_unit)) << 2;
+  return EGB_CamlBits(bits);
 }
 
 static double EGB_U01 (void * bits, void * junk) {
-  return EGB_Bits(bits, junk) / unif01_NORM32;
+  // one must avoid casting the int to a long before the division, because
+  // casting to long fills the other bits with 1, and the result will not give a
+  // number between 0 and 1.
+  return EGB_CamlBits(bits) / unif01_NORM32;
 }
 
 static void WrExternGen (void * junk) {}

--- a/testu01/testu01/unif01_stubs.c
+++ b/testu01/testu01/unif01_stubs.c
@@ -34,10 +34,21 @@ static struct custom_operations unif01_Gen_boxed = {
 };
 
 /* *************************** [ ExternGenBits ] **************************** */
+
 // We reimplement it ourselves instead of using unif01_CreateExternGenBits. It
 // allows us to get rid of the limitation of only one external generator at the
 // same time, which allows a more functional interface of the stubs, and to have
 // only one finalizer for all the various external generators.
+
+// The principle is the following: TestU01 provides a generic 'unif01_Gen' type.
+// This type contains 'GetU01' and 'GetBits' fields that are called to generate
+// the bits. Basically, we would like to put, in these fields, a lambda calling
+// the given OCaml closure. This is however not possible. We thus leverage the
+// fact that 'unif01_Gen' contains also a 'param' field and that this field is
+// provided to the functions in 'GetU01' and 'GetBits'. We store the OCaml
+// closure in that field. The 'GetU01' and 'GetBits' functions can then be
+// written in a static way: they simply take the closure as a parameter and make
+// an OCaml call to it.
 
 static unsigned int CGB_BitsInt (void * bits) {
   return Int_val(caml_callback((value) bits, Val_unit)) << 2;

--- a/testu01/testu01/unif01_stubs.c
+++ b/testu01/testu01/unif01_stubs.c
@@ -107,3 +107,18 @@ value caml_unif01_CreateExternGenBits(value bname, value bbits) {
   CAMLparam2(bname, bbits);
   CAMLreturn(caml_unif01_CreateExternGen(bname, bbits, CGB_U01, CGB_Bits));
 }
+
+/* **************************** [ ExternGen01 ] ***************************** */
+
+static double CG01_U01 (void * bits, void * junk) {
+  return Double_val(caml_callback((value) bits, Val_unit));
+}
+
+static unsigned long CG01_Bits (void * bits, void * junk) {
+  return CG01_U01(bits, junk) * unif01_NORM32;
+}
+
+value caml_unif01_CreateExternGen01(value bname, value bbits) {
+  CAMLparam2(bname, bbits);
+  CAMLreturn(caml_unif01_CreateExternGen(bname, bbits, CG01_U01, CG01_Bits));
+}

--- a/testu01/testu01/unif01_stubs.h
+++ b/testu01/testu01/unif01_stubs.h
@@ -15,4 +15,6 @@ static struct custom_operations unif01_Gen_boxed;
 
 value caml_unif01_CreateExternGenBits(value name, value bits);
 
-value caml_unif01_DeleteExternGenBits(value bgen);
+value caml_unif01_CreateExternGenInt32(value name, value bits);
+
+value caml_unif01_CreateExternGen01(value name, value bits);


### PR DESCRIPTION
This PR:

- reimplements CreateExternGenBits to get rid of the limitation of just one external generator at the same time
- removes DeleteExternGenBits from the bindings
- makes sure (-ish) that the GC is happy
- add CreateExternGenInt32 and CreateExternGen01
- add tests that "bits" doesn't receive more than 30 bits and that "01" doesn't receive a float outside of [0,1)

I suggest to merge in into `testu01`. And to then go back on working on safety (in particular of repeat arrays) in #3.